### PR TITLE
Add Windows compatibility fixes for symlinks and FFmpeg subtitle paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -299,9 +299,11 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
             f.write(f"Dialogue: 0,{start},{end},Default,,0,0,0,,{line}\n")
     
     final_output = output_path.replace('.mp4', '_with_subtitles.mp4')
+    # Use forward slashes for ffmpeg filter paths on Windows
+    ass_file_escaped = ass_file.replace('\\', '/').replace(':', '\\:')
     ffmpeg_cmd = [
         'ffmpeg', '-i', video_path,
-        '-vf', f"ass={ass_file}",
+        '-vf', f"ass={ass_file_escaped}",
         '-c:a', 'copy',
         '-y',
         final_output

--- a/run.py
+++ b/run.py
@@ -1,0 +1,32 @@
+"""Wrapper to fix Windows symlink and encoding issues with HuggingFace Hub."""
+import os
+import sys
+import shutil
+
+os.environ['HF_HUB_DISABLE_SYMLINKS_WARNING'] = '1'
+
+# Fix Windows console encoding for emoji output
+if sys.platform == 'win32':
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+    sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+
+# Patch huggingface_hub to use copies instead of symlinks on Windows
+import huggingface_hub.file_download as fd
+
+original_create_symlink = fd._create_symlink
+
+def _patched_create_symlink(src, dst, new_blob=False):
+    try:
+        original_create_symlink(src, dst, new_blob)
+    except OSError:
+        dst_dir = os.path.dirname(dst)
+        os.makedirs(dst_dir, exist_ok=True)
+        if os.path.exists(dst):
+            os.remove(dst)
+        shutil.copy2(src, dst)
+
+fd._create_symlink = _patched_create_symlink
+
+# Now import and run main
+import runpy
+runpy.run_path('main.py', run_name='__main__')


### PR DESCRIPTION
- run.py: wrapper that patches HuggingFace Hub symlink to use copy fallback and fixes UTF-8 console encoding
- main.py: escape backslashes in FFmpeg subtitle filter path for Windows